### PR TITLE
configurable FileObjectPrefix and UploadInfoObjectPrefix configuration properties

### DIFF
--- a/src/tusdotnet.Stores.S3/TusS3Store.cs
+++ b/src/tusdotnet.Stores.S3/TusS3Store.cs
@@ -83,7 +83,11 @@ public partial class TusS3Store :
         _logger = logger;
         _configuration = configuration;
         _fileIdProvider = fileIdProvider ?? _defaultFileIdProvider;
-        _tusS3Api = new TusS3Api(_logger, s3Client, _configuration.BucketName);
+        _tusS3Api = new TusS3Api(_logger, s3Client, new TusS3BucketConfiguration(
+            BucketName: _configuration.BucketName,
+            UploadInfoObjectPrefix: _configuration.UploadInfoObjectPrefix.TrimEnd('/') + '/',
+            FileObjectPrefix: _configuration.FileObjectPrefix.TrimEnd('/') + '/'
+        ));
     }
 
     /// <summary>

--- a/src/tusdotnet.Stores.S3/TusS3StoreConfiguration.cs
+++ b/src/tusdotnet.Stores.S3/TusS3StoreConfiguration.cs
@@ -8,6 +8,16 @@ public class TusS3StoreConfiguration
     public string BucketName { get; set; } = null!;
 
     /// <summary>
+    /// The key prefix for file objects, the default value is <see cref="TusS3Defines.FileObjectPrefix" />
+    /// </summary>
+    public string FileObjectPrefix { get; set; } = TusS3Defines.FileObjectPrefix;
+
+    /// <summary>
+    /// The key prefix for upload info objects, the default value is <see cref="TusS3Defines.UploadInfoObjectPrefix" />
+    /// </summary>
+    public string UploadInfoObjectPrefix { get; set; } = TusS3Defines.UploadInfoObjectPrefix;
+
+    /// <summary>
     /// MaxPartSize specifies the maximum size of a single part uploaded to S3
     /// in bytes. This value must be bigger than MinPartSize! In order to
     /// choose the correct number, two things have to be kept in mind:


### PR DESCRIPTION
first tentative draft to address issue #3

added two new string configuration properties for setting the FileObjectPrefix and FileObjectPrefix configuration properties, factored out the existing bucket name property into a common configuration container classes so as not to pass in 3 string parameters into the TusS3Api classes which would make them easily interchangeable by accident

default values for the new configuration properties are taken from the previously used constants for backwards compatibility

both parameters are ensured to contain a trailing slash '/' so as not to require checks when these properties are accessed during key calculation

any thoughts/comments as to potential improvements?