### PR TITLE
Object prefix configuration adjustments

### DIFF
--- a/src/tusdotnet.Stores.S3/TusS3Api.cs
+++ b/src/tusdotnet.Stores.S3/TusS3Api.cs
@@ -277,7 +277,7 @@ internal class TusS3Api
             new ListObjectsV2Request
             {
                 BucketName = _bucketConfiguration.BucketName,
-                Prefix = TusS3Defines.UploadInfoObjectPrefix,
+                Prefix = _bucketConfiguration.UploadInfoObjectPrefix,
                 Delimiter = "/"
             });
 
@@ -328,7 +328,7 @@ internal class TusS3Api
             new ListMultipartUploadsRequest()
             {
                 BucketName = _bucketConfiguration.BucketName,
-                Prefix = TusS3Defines.FileObjectPrefix,
+                Prefix = _bucketConfiguration.FileObjectPrefix,
                 Delimiter = "/"
             });
     }

--- a/src/tusdotnet.Stores.S3/TusS3Store.cs
+++ b/src/tusdotnet.Stores.S3/TusS3Store.cs
@@ -75,14 +75,22 @@ public partial class TusS3Store : ITusS3Store
         IAmazonS3 s3Client,
         ITusFileIdProvider? fileIdProvider = null)
     {
+        ValidateConfiguration(configuration);
+        
         _logger = logger;
         _configuration = configuration;
         _fileIdProvider = fileIdProvider ?? _defaultFileIdProvider;
         _tusS3Api = new TusS3Api(_logger, s3Client, new TusS3BucketConfiguration(
             BucketName: _configuration.BucketName,
-            UploadInfoObjectPrefix: _configuration.UploadInfoObjectPrefix.TrimEnd('/') + '/',
-            FileObjectPrefix: _configuration.FileObjectPrefix.TrimEnd('/') + '/'
+            UploadInfoObjectPrefix: _configuration.UploadInfoObjectPrefix.Length > 0 ? _configuration.UploadInfoObjectPrefix.TrimEnd('/') + '/' : string.Empty,
+            FileObjectPrefix: _configuration.FileObjectPrefix.Length > 0 ? _configuration.FileObjectPrefix.TrimEnd('/') + '/' : string.Empty
         ));
+    }
+
+    private static void ValidateConfiguration(TusS3StoreConfiguration configuration)
+    {
+        if (configuration.UploadInfoObjectPrefix == configuration.FileObjectPrefix)
+            throw new ArgumentException("'UploadInfoObjectPrefix' should not be equal to 'FileObjectPrefix'");
     }
 
     /// <summary>


### PR DESCRIPTION
Hello, few adjustments for your project. Please check if it is ok and publish updated nuget package. We would like to use it, but faced with couple of problems:
1. 'RemoveExpiredFilesAsync' internally uses constant values for UploadInfoObjectPrefix and FileObjectPrefix, not the values provided as store configuration
2. It is not possible to use empty prefix for FileObjectPrefix ('/' is always added)

In addition protection method added to ensure UploadInfoObjectPrefix doesn't equal to FileObjectPrefix.
Tests adjusted.

Thank you!