### PR TITLE
Added Support for Disabling Default Checksum Validation and Payload Signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,12 +118,20 @@ var tusConfig = new DefaultTusConfiguration
 
 # Known issues
 
-## Amazon. S3 .AmazonSException: The Content-SHA256 you specified did not match what we received
+## Amazon.S3.AmazonSException: The Content-SHA256 you specified did not match what we received
 
 If you are using an S3 compatible backend you might encounter this error message. 
 This is caused by a change in the AWSSDK.S3 default behaviour see https://github.com/aws/aws-sdk-net/issues/3610                   
 
 It can be mitigated by setting the `RequestChecksumCalculation` to `RequestChecksumCalculation.WHEN_REQUIRED` in the `AmazonS3Config`.
+
+## Amazon.S3.AmazonS3Exception: STREAMING-AWS4-HMAC-SHA256-PAYLOAD not implemented
+
+If you are using Cloudflare R2 as your compatible S3 backend, you might encounter this message.
+This is caused by Cloudflare R2 [currently not supporting](https://developers.cloudflare.com/r2/examples/aws/aws-sdk-net/#upload-and-retrieve-objects)
+the Streaming SigV4 implementation used by AWSSDK.S3.
+
+It can be mitigated by setting `DisableDefaultChecksumValidation` and `DisablePayloadSigning` to `true` in `TusS3StoreConfiguration`.
                                                        
 
 # Special Thanks

--- a/src/tusdotnet.Stores.S3/TusS3Api.cs
+++ b/src/tusdotnet.Stores.S3/TusS3Api.cs
@@ -178,6 +178,8 @@ internal class TusS3Api
 
         UploadPartRequest request = new UploadPartRequest()
         {
+            DisableDefaultChecksumValidation = _bucketConfiguration.DisableDefaultChecksumValidation,
+            DisablePayloadSigning = _bucketConfiguration.DisablePayloadSigning,
             BucketName = _bucketConfiguration.BucketName,
             Key = GetFileKey(uploadInfo.FileId),
             UploadId = uploadInfo.UploadId,
@@ -212,6 +214,8 @@ internal class TusS3Api
 
         PutObjectRequest request = new PutObjectRequest
         {
+            DisableDefaultChecksumValidation = _bucketConfiguration.DisableDefaultChecksumValidation,
+            DisablePayloadSigning = _bucketConfiguration.DisablePayloadSigning,
             BucketName = _bucketConfiguration.BucketName,
             Key = GetUploadInfoKey(uploadInfo.FileId),
             ContentBody = uploadInfoJson,
@@ -334,4 +338,4 @@ internal class TusS3Api
     }
 }
 
-internal record TusS3BucketConfiguration(string BucketName, string UploadInfoObjectPrefix, string FileObjectPrefix);
+internal record TusS3BucketConfiguration(string BucketName, string UploadInfoObjectPrefix, string FileObjectPrefix, bool DisableDefaultChecksumValidation, bool DisablePayloadSigning);

--- a/src/tusdotnet.Stores.S3/TusS3Store.cs
+++ b/src/tusdotnet.Stores.S3/TusS3Store.cs
@@ -83,7 +83,9 @@ public partial class TusS3Store : ITusS3Store
         _tusS3Api = new TusS3Api(_logger, s3Client, new TusS3BucketConfiguration(
             BucketName: _configuration.BucketName,
             UploadInfoObjectPrefix: _configuration.UploadInfoObjectPrefix.Length > 0 ? _configuration.UploadInfoObjectPrefix.TrimEnd('/') + '/' : string.Empty,
-            FileObjectPrefix: _configuration.FileObjectPrefix.Length > 0 ? _configuration.FileObjectPrefix.TrimEnd('/') + '/' : string.Empty
+            FileObjectPrefix: _configuration.FileObjectPrefix.Length > 0 ? _configuration.FileObjectPrefix.TrimEnd('/') + '/' : string.Empty,
+            configuration.DisableDefaultChecksumValidation,
+            configuration.DisablePayloadSigning
         ));
     }
 

--- a/src/tusdotnet.Stores.S3/TusS3StoreConfiguration.cs
+++ b/src/tusdotnet.Stores.S3/TusS3StoreConfiguration.cs
@@ -70,4 +70,14 @@ public class TusS3StoreConfiguration
     /// Limits on how many concurrent part uploads to S3 are allowed.
     /// </summary>
     public int ConcurrentUploadLimit { get; set; } = 10;
+
+    /// <summary>
+    /// Disables the default checksum validation.
+    /// </summary>
+    public bool DisableDefaultChecksumValidation { get; set; } = false;
+
+    /// <summary>
+    /// Disables payload signing.
+    /// </summary>
+    public bool DisablePayloadSigning { get; set; } = false;
 }


### PR DESCRIPTION
I use Cloudflare R2 as my S3 back-end, but it currently does not support the Streaming SigV4 implementation used by the AWS S3 SDK. I've added a way to disable it based on [Cloudflare's recommended fix](https://developers.cloudflare.com/r2/examples/aws/aws-sdk-net/#upload-and-retrieve-objects).